### PR TITLE
Changed slugs to templates

### DIFF
--- a/tempalte-menu.php
+++ b/tempalte-menu.php
@@ -1,3 +1,4 @@
+<?php /* Template Name: Menu Template */ ?>
 <?php get_header(); ?>
 
 <div class="section-header stone">

--- a/template-booking.php
+++ b/template-booking.php
@@ -1,3 +1,4 @@
+<?php /* Template Name: Booking Template */ ?>
 <?php get_header(); ?>
 
 <div class="section paper">

--- a/template-default.php
+++ b/template-default.php
@@ -1,3 +1,4 @@
+<?php /* Template Name: Default Template */ ?>
 <?php get_header(); ?>
 
 <div class="section light">

--- a/template-events.php
+++ b/template-events.php
@@ -1,3 +1,4 @@
+<?php /* Template Name: Events Template */ ?>
 <?php get_header(); ?>
 
 <div class="section-header stone">

--- a/template-rooms.php
+++ b/template-rooms.php
@@ -1,3 +1,4 @@
+<?php /* Template Name: Rooms Template */ ?>
 <?php get_header(); ?>
 
 <div class="section-header stone">


### PR DESCRIPTION
From now on, custom templates are used to determine the layout of a page, instead of using slugs to assign them to pages.
Main reason is to make is easier to implement multiple languages with Polylang.

